### PR TITLE
cli: allows the use of an empty string in the `warp-slot` argument of the solana-test-validator (fix)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -379,6 +379,8 @@ jobs:
             path: tests/custom-coder
           - cmd: cd tests/validator-clone && yarn --frozen-lockfile && anchor test --skip-lint
             path: tests/validator-clone
+          - cmd: cd tests/validator-warp-slot && yarn --frozen-lockfile && anchor test --skip-lint
+            path: tests/validator-warp-slot
           - cmd: cd tests/cpi-returns && anchor test --skip-lint
             path: tests/cpi-returns
           - cmd: cd tests/multiple-suites && anchor test --skip-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 * avm: `avm install` no longer downloads the version if already installed in the machine ([#1670](https://github.com/project-serum/anchor/pull/1670)).
 * cli: make `anchor test` fail when used with `--skip-deploy` option and without `--skip-local-validator` option but there already is a running validator ([#1675](https://github.com/project-serum/anchor/pull/1675)).
+* cli: allows the use of an empty string in the `warp-slot` argument of the solana-test-validator ([#1728](https://github.com/project-serum/anchor/pull/1728)).
 * lang: Return proper error instead of panicking if account length is smaller than discriminator in functions of `(Account)Loader` ([#1678](https://github.com/project-serum/anchor/pull/1678)).
 
 ### Breaking

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2107,7 +2107,15 @@ fn validator_flags(
                     // Remaining validator flags are non-array types
                     flags.push(format!("--{}", key.replace('_', "-")));
                     if let serde_json::Value::String(v) = value {
-                        flags.push(v.to_string());
+                        if key == "warp_slot" && v.is_empty() {
+                            if !entries.as_object().unwrap().contains_key("url") {
+                                return Err(anyhow!(
+                                    "Validator url for Solana's JSON RPC should be provided in order to get its current slot"
+                                ));
+                            }
+                        } else {
+                            flags.push(v.to_string());
+                        }
                     } else {
                         flags.push(value.to_string());
                     }

--- a/tests/package.json
+++ b/tests/package.json
@@ -30,6 +30,7 @@
     "tictactoe",
     "typescript",
     "validator-clone",
+    "validator-warp-slot",
     "zero-copy",
     "declare-id",
     "cpi-returns",

--- a/tests/validator-warp-slot/Anchor.toml
+++ b/tests/validator-warp-slot/Anchor.toml
@@ -1,0 +1,21 @@
+[features]
+seeds = false
+[programs.localnet]
+validator_warp_slot = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+
+[registry]
+url = "https://anchor.projectserum.com"
+
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+
+[test]
+startup_wait = 20000
+
+[test.validator]
+url = "https://api.mainnet-beta.solana.com"
+warp_slot = ""

--- a/tests/validator-warp-slot/Cargo.toml
+++ b/tests/validator-warp-slot/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+    "programs/*"
+]

--- a/tests/validator-warp-slot/package.json
+++ b/tests/validator-warp-slot/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "validator-warp-slot",
+  "version": "0.22.0",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/project-serum/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/project-serum/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/project-serum/anchor.git"
+  },
+  "engines": {
+    "node": ">=11"
+  },
+  "scripts": {
+    "test": "anchor run test-with-build"
+  }
+}

--- a/tests/validator-warp-slot/programs/validator-warp-slot/Cargo.toml
+++ b/tests/validator-warp-slot/programs/validator-warp-slot/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "validator-warp-slot"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "validator_warp_slot"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }

--- a/tests/validator-warp-slot/programs/validator-warp-slot/Xargo.toml
+++ b/tests/validator-warp-slot/programs/validator-warp-slot/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/validator-warp-slot/programs/validator-warp-slot/src/lib.rs
+++ b/tests/validator-warp-slot/programs/validator-warp-slot/src/lib.rs
@@ -1,0 +1,19 @@
+use anchor_lang::prelude::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod validator_warp_slot {
+    use super::*;
+
+    pub fn initialize(_ctx: Context<Initialize>, mainnet_slot: u64) -> Result<()> {
+        // mainnet clock data is fetched after starting the validator; allow some tolerance
+        let tolerance: u64 = 100;
+        let test_validator_slot = Clock::get().unwrap().slot;
+        assert!(mainnet_slot - test_validator_slot < tolerance);
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize {}

--- a/tests/validator-warp-slot/tests/validator-warp-slot.ts
+++ b/tests/validator-warp-slot/tests/validator-warp-slot.ts
@@ -1,0 +1,30 @@
+import * as anchor from "@project-serum/anchor";
+import { Program } from "@project-serum/anchor";
+import { ValidatorWarpSlot } from "../target/types/validator_warp_slot";
+
+describe("validator-warp-slot", () => {
+  // Configure the client to use the local cluster.
+  anchor.setProvider(anchor.Provider.env());
+
+  const program = anchor.workspace
+    .ValidatorWarpSlot as Program<ValidatorWarpSlot>;
+
+  it("Is initialized!", async () => {
+    const mainnetConnection = new anchor.web3.Connection(
+      "https://api.mainnet-beta.solana.com"
+    );
+
+    const [clockInfo] = await anchor.utils.rpc.getMultipleAccounts(
+      mainnetConnection,
+      [anchor.web3.SYSVAR_CLOCK_PUBKEY]
+    );
+
+    if (!clockInfo) {
+      throw new Error("Unable to fetch clock account from mainnet");
+    }
+
+    const mainnetSlot = new anchor.BN(clockInfo.account.data.slice(0, 8), "le");
+    const tx = await program.methods.initialize(mainnetSlot).rpc();
+    console.log("Your transaction signature", tx);
+  });
+});

--- a/tests/validator-warp-slot/tests/validator-warp-slot.ts
+++ b/tests/validator-warp-slot/tests/validator-warp-slot.ts
@@ -9,7 +9,7 @@ describe("validator-warp-slot", () => {
   const program = anchor.workspace
     .ValidatorWarpSlot as Program<ValidatorWarpSlot>;
 
-  it("Is initialized!", async () => {
+  it("Has the same slot as mainnet", async () => {
     const mainnetConnection = new anchor.web3.Connection(
       "https://api.mainnet-beta.solana.com"
     );
@@ -25,6 +25,6 @@ describe("validator-warp-slot", () => {
 
     const mainnetSlot = new anchor.BN(clockInfo.account.data.slice(0, 8), "le");
     const tx = await program.methods.initialize(mainnetSlot).rpc();
-    console.log("Your transaction signature", tx);
+    console.log("tx signature:", tx);
   });
 });

--- a/tests/validator-warp-slot/tsconfig.json
+++ b/tests/validator-warp-slot/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
Fixes the problem described below

---

With the flag `--warp-slot` of the `solana-test-validator`, it is possible to jump to an arbitrary slot, either to the one specified after the argument, or if left blank, to the current one referenced by the `--url` argument:

```
$ solana-test-validator --help
    [...]
    -w, --warp-slot <WARP_SLOT>
            Warp the ledger to WARP_SLOT after starting the validator. If no slot is provided then the current slot of
            the cluster referenced by the --url argument will be used
```

however, if an empty string is specified in the `Anchor.toml` such as

```
[test.validator]
url = "https://api.mainnet-beta.solana.com"
warp_slot = ""
```

the validator fails to start, and the log reports `error: Invalid value for '--warp-slot <WARP_SLOT>': error parsing '': cannot parse integer from empty string`


