### PR TITLE
cli: run tests in multiple processes

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -269,6 +269,7 @@ impl<T> std::ops::DerefMut for WithPath<T> {
 pub struct Config {
     pub anchor_version: Option<String>,
     pub solana_version: Option<String>,
+    pub mptest: Option<MultiProcessTestConfig>,
     pub features: FeaturesConfig,
     pub registry: RegistryConfig,
     pub provider: ProviderConfig,
@@ -288,6 +289,14 @@ pub struct FeaturesConfig {
     pub seeds: bool,
     #[serde(default, rename = "skip-lint")]
     pub skip_lint: bool,
+}
+
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct MultiProcessTestConfig {
+    #[serde(default)]
+    pub cmd: String,
+    #[serde(default)]
+    pub tests: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -409,6 +418,7 @@ impl Config {
 struct _Config {
     anchor_version: Option<String>,
     solana_version: Option<String>,
+    mptest: Option<MultiProcessTestConfig>,
     features: Option<FeaturesConfig>,
     programs: Option<BTreeMap<String, BTreeMap<String, serde_json::Value>>>,
     registry: Option<RegistryConfig>,
@@ -437,6 +447,7 @@ impl ToString for Config {
         let cfg = _Config {
             anchor_version: self.anchor_version.clone(),
             solana_version: self.solana_version.clone(),
+            mptest: self.mptest.clone(),
             features: Some(self.features.clone()),
             registry: Some(self.registry.clone()),
             provider: Provider {
@@ -466,6 +477,7 @@ impl FromStr for Config {
         Ok(Config {
             anchor_version: cfg.anchor_version,
             solana_version: cfg.solana_version,
+            mptest: cfg.mptest,
             features: cfg.features.unwrap_or_default(),
             registry: cfg.registry.unwrap_or_default(),
             provider: ProviderConfig {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -599,9 +599,9 @@ fn init(cfg_override: &ConfigOverride, name: String, javascript: bool, no_git: b
             idl: None,
         },
     );
-    cfg.mptest = Some(config::MultiProcessTestConfig{
+    cfg.mptest = Some(config::MultiProcessTestConfig {
         cmd: "yarn run ts-mocha -p ./tsconfig.json -t 1000000".to_string(),
-        tests: "./tests/".to_string()
+        tests: "./tests/".to_string(),
     });
     cfg.programs.insert(Cluster::Localnet, localnet);
     let toml = cfg.to_string();


### PR DESCRIPTION
For projects with many independent test cases, running tests takes painfully long.
Since test cases are independent, we can run all of them in parallel against one single instance of test validator.
This PR implements:

1. a new cmd line option, `mp_test`, to run tests in parallel.
2. a new option in `Anchor.toml`, `mptest`, which specifies the details of multi-process test.

`mptest.cmd`: the command used to run the tests
`mptest.tests`: path to the folder that contains all test cases. Each test case is a single `.ts` file.

We launch a single instance of test validator, and launch one process for each `.ts` file.