### PR TITLE
update escrow test to work with non-deprecated methods

### DIFF
--- a/tests/escrow/tests/escrow.ts
+++ b/tests/escrow/tests/escrow.ts
@@ -4,9 +4,7 @@ import {
   PublicKey,
   Keypair,
   SystemProgram,
-  Connection,
-  clusterApiUrl,
-} from "@solana/web3.js";
+  } from "@solana/web3.js";
 import { TOKEN_PROGRAM_ID, Token } from "@solana/spl-token";
 import { assert } from "chai";
 import { Escrow } from "../target/types/escrow";


### PR DESCRIPTION
Updates the escrow typescript test to work with the new endpoints:
- `provider.connection.confirmTransaction() updated`
- `program.rpc.*` -> `program.methods.*.rpc()`

Also updates the logic of the tests so that a lot of logic is in the `beforeEach()`, which allows you to skip tests without breaking following tests. 