### PR TITLE
RFC: add discriminator to idl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "anchor-attribute-discriminator"
+version = "0.25.0"
+dependencies = [
+ "anchor-syn",
+ "proc-macro2 1.0.40",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "anchor-attribute-error"
 version = "0.25.0"
 dependencies = [
@@ -257,6 +266,7 @@ dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
  "anchor-attribute-constant",
+ "anchor-attribute-discriminator",
  "anchor-attribute-error",
  "anchor-attribute-event",
  "anchor-attribute-interface",

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -16,6 +16,7 @@ anchor-debug = [
     "anchor-attribute-access-control/anchor-debug",
     "anchor-attribute-account/anchor-debug",
     "anchor-attribute-constant/anchor-debug",
+    "anchor-attribute-discriminator/anchor-debug",
     "anchor-attribute-error/anchor-debug",
     "anchor-attribute-event/anchor-debug",
     "anchor-attribute-interface/anchor-debug",
@@ -29,6 +30,7 @@ anchor-debug = [
 anchor-attribute-access-control = { path = "./attribute/access-control", version = "0.25.0" }
 anchor-attribute-account = { path = "./attribute/account", version = "0.25.0" }
 anchor-attribute-constant = { path = "./attribute/constant", version = "0.25.0" }
+anchor-attribute-discriminator = { path = "./attribute/discriminator", version = "0.25.0" }
 anchor-attribute-error = { path = "./attribute/error", version = "0.25.0" }
 anchor-attribute-program = { path = "./attribute/program", version = "0.25.0" }
 anchor-attribute-state = { path = "./attribute/state", version = "0.25.0" }

--- a/lang/attribute/discriminator/Cargo.toml
+++ b/lang/attribute/discriminator/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "anchor-attribute-discriminator"
+version = "0.25.0"
+authors = ["Serum Foundation <foundation@projectserum.com>"]
+repository = "https://github.com/coral-xyz/anchor"
+license = "Apache-2.0"
+description = "Anchor attribute macro for creating discriminator types"
+rust-version = "1.56"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[features]
+anchor-debug = ["anchor-syn/anchor-debug"]
+
+[dependencies]
+proc-macro2 = "1.0"
+syn = { version = "1.0.60", features = ["full"] }
+anchor-syn = { path = "../../syn", version = "0.25.0" }

--- a/lang/attribute/discriminator/src/lib.rs
+++ b/lang/attribute/discriminator/src/lib.rs
@@ -1,0 +1,10 @@
+extern crate proc_macro;
+
+/// A marker attribute used to override the discriminator value that should be used.
+#[proc_macro_attribute]
+pub fn discriminator(
+    _attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    input
+}

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -47,6 +47,7 @@ pub use crate::bpf_upgradeable_state::*;
 pub use anchor_attribute_access_control::access_control;
 pub use anchor_attribute_account::{account, declare_id, zero_copy};
 pub use anchor_attribute_constant::constant;
+pub use anchor_attribute_discriminator::discriminator;
 pub use anchor_attribute_error::*;
 pub use anchor_attribute_event::{emit, event};
 pub use anchor_attribute_interface::interface;
@@ -238,9 +239,10 @@ pub mod prelude {
         accounts::account_loader::AccountLoader, accounts::program::Program,
         accounts::signer::Signer, accounts::system_account::SystemAccount,
         accounts::sysvar::Sysvar, accounts::unchecked_account::UncheckedAccount, constant,
-        context::Context, context::CpiContext, declare_id, emit, err, error, event, interface,
-        program, require, require_eq, require_gt, require_gte, require_keys_eq, require_keys_neq,
-        require_neq, solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source, state,
+        context::Context, context::CpiContext, declare_id, discriminator, emit, err, error, event,
+        interface, program, require, require_eq, require_gt, require_gte, require_keys_eq,
+        require_keys_neq, require_neq,
+        solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source, state,
         system_program::System, zero_copy, AccountDeserialize, AccountSerialize, Accounts,
         AccountsExit, AnchorDeserialize, AnchorSerialize, Id, Key, Owner, ProgramData, Result,
         ToAccountInfo, ToAccountInfos, ToAccountMetas,

--- a/lang/syn/src/idl/file.rs
+++ b/lang/syn/src/idl/file.rs
@@ -83,6 +83,7 @@ pub fn parse(
                                 );
                                 IdlInstruction {
                                     name,
+                                    discriminator: None,
                                     docs: None,
                                     accounts,
                                     args,
@@ -131,6 +132,7 @@ pub fn parse(
                         idl_accounts(&ctx, accounts_strct, &accs, seeds_feature, no_docs);
                     IdlInstruction {
                         name,
+                        discriminator: None,
                         docs: None,
                         accounts,
                         args,
@@ -216,6 +218,7 @@ pub fn parse(
             };
             IdlInstruction {
                 name: ix.ident.to_string().to_mixed_case(),
+                discriminator: ix.discriminator.clone(),
                 docs: ix.docs.clone(),
                 accounts,
                 args,

--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -46,6 +46,8 @@ pub struct IdlState {
 pub struct IdlInstruction {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub discriminator: Option<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub docs: Option<Vec<String>>,
     pub accounts: Vec<IdlAccountItem>,
     pub args: Vec<IdlField>,

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -85,6 +85,7 @@ pub struct StateInterface {
 pub struct Ix {
     pub raw_method: ItemFn,
     pub ident: Ident,
+    pub discriminator: Option<Vec<u8>>,
     pub docs: Option<Vec<String>>,
     pub args: Vec<IxArg>,
     pub returns: IxReturn,


### PR DESCRIPTION
This adds the following syntax:

```
#[discriminator(0xffefabcd)]
pub fn initialize(ctx: Context<Initialize>, data: u64) -> Result<()> {
      Ok(())
}
```

This PR is not complete yet - the code generation does not use the discriminator yet, and the client should also use the new value.
