### PR TITLE
fix: Fix error message formatting Update common.rs

### DIFF
--- a/lang/syn/src/idl/common.rs
+++ b/lang/syn/src/idl/common.rs
@@ -13,7 +13,7 @@ pub fn find_path(name: &str, path: impl AsRef<Path>) -> Result<PathBuf> {
         }
     }
 
-    Err(anyhow!("Path ({path:?}) not found"))
+    Err(anyhow!("Path ({:?}) not found", path))
 }
 
 pub fn get_no_docs() -> bool {


### PR DESCRIPTION
The error message `Err(anyhow!("Path ({path:?}) not found"))` was incorrectly formatted. Rust was interpreting `{path:?}` as a literal instead of substituting the variable.

I fixed it to use the correct formatting: `Err(anyhow!("Path ({:?}) not found", path))`.  