### PR TITLE
Typo fix 0.30.1.md

### DIFF
--- a/docs/src/pages/release-notes/0.30.1.md
+++ b/docs/src/pages/release-notes/0.30.1.md
@@ -112,7 +112,7 @@ Making changes to the IDL crate, e.g. adding features such as the [`convert`](ht
 
 To fix this problem, a new [crate](https://docs.rs/anchor-lang-idl-spec) that only includes the IDL spec has been introduced. The new crate's version will be used in the `idl.metadata.spec` field to differentiate between various IDLs.
 
-**NOTE:** This crate is accesible via the main IDL crate from [`anchor_lang_idl::types`](https://docs.rs/anchor-lang-idl/0.1.1/anchor_lang_idl/types/index.html).
+**NOTE:** This crate is accessible via the main IDL crate from [`anchor_lang_idl::types`](https://docs.rs/anchor-lang-idl/0.1.1/anchor_lang_idl/types/index.html).
 
 ## CLI
 


### PR DESCRIPTION
# Typo Fix in `0.30.1.md`

## Description

This pull request addresses a typographical error in the **`0.30.1.md`** release notes file located in the `docs/src/pages/release-notes` directory:

- **Typo:** Corrected "accesible" to "accessible" in a note:
  - **Original:** "This crate is accesible via the main IDL crate..."
  - **Corrected:** "This crate is accessible via the main IDL crate..."

### Changes
- **File:** `docs/src/pages/release-notes/0.30.1.md`
- **Details:**
  - Fixed the spelling mistake for improved accuracy and readability.

## Why This Matters

- Enhances the clarity and professionalism of the release notes.
- Avoids potential confusion for users referencing the documentation.

## Checklist

- [x] Identified and corrected the typo.
- [x] Verified no other errors were introduced or overlooked.
- [x] Followed the project's [contribution guidelines](https://github.com/coral-xyz/anchor/blob/master/CONTRIBUTING.md).

---

### Notes for Reviewers

This is a straightforward and minor fix that does not impact functionality. Please let me know if there are additional adjustments needed. Thanks for reviewing!
