### PR TITLE
fix(cli): Ensure absolute IDL file paths in CLI commands (#2993)

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2389,10 +2389,13 @@ fn idl_init(
     idl_filepath: String,
     priority_fee: Option<u64>,
 ) -> Result<()> {
+    // Convert relative path to absolute path before changing directories
+    let idl_filepath = std::env::current_dir()?.join(&idl_filepath);
+    
     with_workspace(cfg_override, |cfg| {
         let keypair = cfg.provider.wallet.to_string();
 
-        let idl = fs::read(idl_filepath)?;
+        let idl = fs::read(&idl_filepath)?;
         let idl = convert_idl(&idl)?;
 
         let idl_address = create_idl_account(cfg, &keypair, &program_id, &idl, priority_fee)?;
@@ -2423,10 +2426,13 @@ fn idl_write_buffer(
     idl_filepath: String,
     priority_fee: Option<u64>,
 ) -> Result<Pubkey> {
+    // Convert relative path to absolute path before changing directories
+    let idl_filepath = std::env::current_dir()?.join(&idl_filepath);
+    
     with_workspace(cfg_override, |cfg| {
         let keypair = cfg.provider.wallet.to_string();
 
-        let idl = fs::read(idl_filepath)?;
+        let idl = fs::read(&idl_filepath)?;
         let idl = convert_idl(&idl)?;
 
         let idl_buffer = create_idl_buffer(cfg, &keypair, &program_id, &idl, priority_fee)?;

--- a/tests/anchor-cli-idl/tests/idl.ts
+++ b/tests/anchor-cli-idl/tests/idl.ts
@@ -84,4 +84,19 @@ describe("Test CLI IDL commands", () => {
     );
     assert.deepEqual(idlActual, idlExpected);
   });
+
+  it("Can initialize IDL account with relative path from subdirectory", async () => {
+    // Close the IDL account first to reset state
+    execSync(`anchor idl close ${programOne.programId}`, { stdio: "inherit" });
+    
+    // Test the relative path fix by running from target/idl directory
+    execSync(
+      `cd target/idl && anchor idl init --filepath idl_commands_one.json ${programOne.programId}`,
+      { stdio: "inherit" }
+    );
+    
+    // Verify the IDL was correctly initialized
+    const idl = await anchor.Program.fetchIdl(programOne.programId, provider);
+    assert.deepEqual(idl, programOne.rawIdl);
+  });
 });


### PR DESCRIPTION
This pull request improves the handling of file paths in IDL-related CLI commands by ensuring relative paths are converted to absolute paths before processing. Additionally, it introduces a new test to validate this behavior.

### Enhancements to file path handling:
* [`cli/src/lib.rs`](diffhunk://#diff-c1f8f7498da827a634bddc8a7559198bc99b296e9d9e8b91a70b503662995b8cR2392-R2398): Updated `idl_init` and `idl_write_buffer` functions to convert relative file paths to absolute paths using `std::env::current_dir()?.join(&idl_filepath)` before processing. This ensures consistent behavior regardless of the current working directory. [[1]](diffhunk://#diff-c1f8f7498da827a634bddc8a7559198bc99b296e9d9e8b91a70b503662995b8cR2392-R2398) [[2]](diffhunk://#diff-c1f8f7498da827a634bddc8a7559198bc99b296e9d9e8b91a70b503662995b8cR2429-R2435)

### New test for relative path handling:
* [`tests/anchor-cli-idl/tests/idl.ts`](diffhunk://#diff-8bd692c8c2a0b71fcf0233886cd44b45883ab9b0693df4973acbe19c240ed903R87-R101): Added a test case to verify that the `anchor idl init` command correctly handles relative paths when executed from a subdirectory. This includes resetting the IDL account state, initializing it using a relative path, and validating the resulting IDL.