### PR TITLE
feat: Enhance test generation for JavaScript and TypeScript

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -686,11 +686,20 @@ impl TestTemplate {
                 // Build the test suite.
                 fs::create_dir_all("tests")?;
 
-                let mut test = File::create(format!("tests/{}.test.js", &project_name))?;
-                if solidity {
-                    test.write_all(solidity_template::jest(project_name).as_bytes())?;
+                if js {
+                    let mut test = File::create(format!("tests/{}.test.js", &project_name))?;
+                    if solidity {
+                        test.write_all(solidity_template::jest(project_name).as_bytes())?;
+                    } else {
+                        test.write_all(jest(project_name).as_bytes())?;
+                    }
                 } else {
-                    test.write_all(jest(project_name).as_bytes())?;
+                    let mut test = File::create(format!("tests/{}.test.ts", &project_name))?;
+                    if solidity {
+                        test.write_all(solidity_template::ts_jest(project_name).as_bytes())?;
+                    } else {
+                        test.write_all(ts_jest(project_name).as_bytes())?;
+                    }
                 }
             }
             Self::Rust => {

--- a/cli/src/solidity_template.rs
+++ b/cli/src/solidity_template.rs
@@ -159,3 +159,56 @@ describe("{}", () => {{
         name.to_upper_camel_case(),
     )
 }
+
+pub fn ts_jest(name: &str) -> String {
+    format!(
+        r#"import * as anchor from "@coral-xyz/anchor";
+import {{ Program }} from "@coral-xyz/anchor";
+import {{ {} }} from "../target/types/{}";
+
+describe("{}", () => {{
+  // Configure the client to use the local cluster.
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const dataAccount = anchor.web3.Keypair.generate();
+
+  const program = anchor.workspace.{} as Program<{}>;
+
+  it("Is initialized!", async () => {{
+    // Add your test here.
+    const tx = await program.methods
+      .new()
+      .accounts({{ dataAccount: dataAccount.publicKey }})
+      .signers([dataAccount])
+      .rpc();
+    console.log("Your transaction signature", tx);
+
+    const val1 = await program.methods
+      .get()
+      .accounts({{ dataAccount: dataAccount.publicKey }})
+      .view();
+
+    console.log("state", val1);
+
+    await program.methods
+      .flip()
+      .accounts({{ dataAccount: dataAccount.publicKey }})
+      .rpc();
+
+    const val2 = await program.methods
+      .get()
+      .accounts({{ dataAccount: dataAccount.publicKey }})
+      .view();
+
+    console.log("state", val2);
+  }});
+}});
+"#,
+        name.to_upper_camel_case(),
+        name.to_snake_case(),
+        name,
+        name.to_upper_camel_case(),
+        name.to_upper_camel_case(),
+    )
+}


### PR DESCRIPTION
Fixes #3736

This pull request introduces TypeScript support for test generation in the CLI tool, alongside existing JavaScript support. It includes changes to dynamically generate TypeScript test files based on user preferences and adds a new template for TypeScript tests specifically tailored for Solidity projects.

### TypeScript Test File Generation:

* [`cli/src/rust_template.rs`](diffhunk://#diff-caba398fa4ca1762b150abb98bffb6a49bb4398c43e900e588511209a88aa453R689-R703): Updated the `TestTemplate` implementation to conditionally generate either JavaScript or TypeScript test files based on the `js` flag. TypeScript test files use a new template function for Solidity projects.

### TypeScript Test Template for Solidity:

* [`cli/src/solidity_template.rs`](diffhunk://#diff-355030f5caa28ff255c850c4a5ab42d1d62768cc7ceeaac52582d3737fff5270R162-R214): Added a new `ts_jest` function to generate TypeScript test templates for Solidity projects. This includes configuration for the Anchor framework and example test methods for initialization, state retrieval, and state modification.