### PR TITLE
fix: SystemAccount compilation error in #[derive(Accounts)] macro (#3696)

### DIFF
--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -441,6 +441,22 @@ impl Field {
                     }
                 }
             }
+            Ty::Signer => {
+                quote! {
+                    match Signer::try_from(&#field) {
+                        Ok(val) => val,
+                        Err(e) => return Err(e.with_account_name(#field_str))
+                    }
+                }
+            }
+            Ty::SystemAccount => {
+                quote! {
+                    match SystemAccount::try_from(&#field) {
+                        Ok(val) => val,
+                        Err(e) => return Err(e.with_account_name(#field_str))
+                    }
+                }
+            }
             _ => {
                 if checked {
                     quote! {

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -835,3 +835,14 @@ pub struct TestInitAndZero<'info> {
     pub payer: Signer<'info>,
     pub system_program: Program<'info, System>,
 }
+
+#[derive(Accounts)]
+pub struct TestSystemAccount<'info> {
+    #[account(init, payer = user, space = 0)]
+    pub system_account: SystemAccount<'info>,
+    #[account(mut)]
+    pub user: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -409,4 +409,8 @@ pub mod misc {
     pub fn test_init_and_zero(_ctx: Context<TestInitAndZero>) -> Result<()> {
         Ok(())
     }
+
+    pub fn test_system_account(_ctx: Context<TestSystemAccount>) -> Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Problem

Using `SystemAccount<'info>` as a field in a struct with `#[derive(Accounts)]` was causing compilation errors:

```rust
error[E0425]: cannot find crate `try_from_unchecked` in the list of imported crates
error[E0425]: cannot find crate `try_from` in the list of imported crates
```

**Reproduction case:**
```rust
#[derive(Accounts)]
pub struct Initialize<'info> {
    #[account(init, payer = user, space = 0)]
    pub system_account: SystemAccount<'info>,  // ❌ This failed to compile
    #[account(mut, signer)]
    pub user: Signer<'info>,
    pub system_program: Program<'info, System>,
}
```

## Root Cause

The issue occurred in `lang/syn/src/lib.rs` in the `from_account_info` method:

1. **SystemAccount** and **Signer** have `try_from` methods that take only **one parameter** (`AccountInfo`)
2. However, they were falling through to the default `_` case which generates code for **two parameters**
3. The default case generates: `#container_ty::try_from(#owner_addr, &#field)`
4. For SystemAccount, `container_ty()` returns `quote! {}` (empty), making this: `::try_from(owner_addr, &field)` ❌
5. But `SystemAccount::try_from` only accepts: `try_from(info: &AccountInfo)` ✅

## Solution

Added specific cases for `SystemAccount` and `Signer` in the `from_account_info` method to generate the correct single-parameter `try_from` calls:

```rust
Ty::SystemAccount => {
    quote! {
        match SystemAccount::try_from(&#field) {
            Ok(val) => val,
            Err(e) => return Err(e.with_account_name(#field_str))
        }
    }
}
Ty::Signer => {
    quote! {
        match Signer::try_from(&#field) {
            Ok(val) => val,
            Err(e) => return Err(e.with_account_name(#field_str))
        }
    }
}
```

## Testing

✅ **Compilation Tests:**
- `cargo build --workspace --exclude anchor-cli` - SUCCESS
- `tests/system-accounts` program builds (has existing SystemAccount usage)
- `tests/misc` program builds (added test case)

✅ **Validation:**
- The existing `tests/system-accounts/programs/system-accounts/src/lib.rs` already contains the exact failing pattern and now compiles successfully
- No regressions: all other account types (Account, AccountLoader, UncheckedAccount, etc.) continue to work as before

✅ **CI Integration:**
- SystemAccount tests are already part of the CI pipeline via `tests/system-accounts`

## Files Changed

- **`lang/syn/src/lib.rs`** - Core fix: Added specific cases for SystemAccount and Signer
- **`tests/misc/programs/misc/src/context.rs`** - Added test case for SystemAccount
- **`tests/misc/programs/misc/src/lib.rs`** - Added test handler

## Backward Compatibility

✅ **Fully backward compatible** - no existing code needs to change. This only fixes previously broken SystemAccount usage.

Closes #3696