### PR TITLE
Refactor: Removes anchor publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The minor version will be incremented upon a breaking change and the patch versi
 - lang: Add `#[error]` attribute to `declare_program!` ([#3757](https://github.com/coral-xyz/anchor/pull/3757)).
 - cli: Replace `anchor verify` to use `solana-verify` under the hood, adding automatic installation via AVM, local path support, and future-proof argument passing ([#3768](https://github.com/solana-foundation/anchor/pull/3768)).
 
+### Removed
+
+- cli: Remove deprecated `anchor publish` command and related code as it's no longer maintained
+
 ### Fixes
 
 - docker: Upgrade `node` to 20.18.0 LTS ([#3687](https://github.com/solana-foundation/anchor/pull/3687)).

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1399,30 +1399,6 @@ pub struct ProgramWorkspace {
     pub idl: Idl,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct AnchorPackage {
-    pub name: String,
-    pub address: String,
-    pub idl: Option<String>,
-}
-
-impl AnchorPackage {
-    pub fn from(name: String, cfg: &WithPath<Config>) -> Result<Self> {
-        let cluster = &cfg.provider.cluster;
-        if cluster != &Cluster::Mainnet {
-            return Err(anyhow!("Publishing requires the mainnet cluster"));
-        }
-        let program_details = cfg
-            .programs
-            .get(cluster)
-            .ok_or_else(|| anyhow!("Program not provided in Anchor.toml"))?
-            .get(&name)
-            .ok_or_else(|| anyhow!("Program not provided in Anchor.toml"))?;
-        let idl = program_details.idl.clone();
-        let address = program_details.address.to_string();
-        Ok(Self { name, address, idl })
-    }
-}
 
 #[macro_export]
 macro_rules! home_path {


### PR DESCRIPTION
Removes anchor publish completely as unused.

- Removed the Publish variant from the Command enum in cli/src/lib.rs
- Deleted the publish function impl in the same.
- Removed the AnchorPackage struct and its impl from cli/src/config.rs