### PR TITLE
use stable toolchain for idl build

### DIFF
--- a/idl/src/build.rs
+++ b/idl/src/build.rs
@@ -138,10 +138,9 @@ fn build(
     no_docs: bool,
     cargo_args: &[String],
 ) -> Result<Idl> {
-    // `nightly` toolchain is currently required for building the IDL.
     let toolchain = std::env::var("RUSTUP_TOOLCHAIN")
         .map(|toolchain| format!("+{toolchain}"))
-        .unwrap_or_else(|_| "+nightly".to_string());
+        .unwrap_or_else(|_| "+stable".to_string());
 
     install_toolchain_if_needed(&toolchain)?;
     let output = Command::new("cargo")


### PR DESCRIPTION
This PR updates the IDL build process to use the stable Rust toolchain by default.
It ensures more predictable and stable builds, as requested in #3775