### PR TITLE
Add nightly build workflow and update README with nightly build instructions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,88 @@
+name: Nightly Release
+
+on:
+  schedule:
+    # Run daily at midnight UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+
+      # Generate nightly version
+      - run: |
+          DATE=$(date +%Y%m%d)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          NIGHTLY_VERSION="0.0.0-nightly-${DATE}-${SHORT_SHA}"
+          echo "NIGHTLY_VERSION=${NIGHTLY_VERSION}" >> $GITHUB_ENV
+        shell: bash
+
+      # Build CLI
+      - run: cargo build --package anchor-cli --release
+      - run: cd cli/npm-package && npm pack
+      - run: cp cli/npm-package/*.tgz ./anchor-cli-${NIGHTLY_VERSION}.tgz
+        shell: bash
+
+      # Build TypeScript package
+      - run: cd ts && npm install
+      - run: cd ts/packages/anchor && npm run build && npm pack
+      - run: cp ts/packages/anchor/*.tgz ./anchor-${NIGHTLY_VERSION}.tgz
+        shell: bash
+
+      # Create GitHub release with both packages
+      - name: Create GitHub release
+        run: |
+          gh release create "nightly-${NIGHTLY_VERSION}" \
+            --title "Nightly Build ${NIGHTLY_VERSION}" \
+            --notes "**Nightly Build** - ${NIGHTLY_VERSION}
+
+          This is an automated nightly build from the latest \`master\` branch.
+
+          **⚠️ WARNING: Nightly builds are unstable and may contain breaking changes!**
+
+          ## Installation
+
+          ### CLI
+          \`\`\`bash
+          npm install -g @coral-xyz/anchor-cli@${NIGHTLY_VERSION}
+          \`\`\`
+
+          ### TypeScript Package
+          \`\`\`bash
+          npm install @coral-xyz/anchor@${NIGHTLY_VERSION}
+          \`\`\`
+
+          Or reference the tarballs directly in your package.json:
+
+          \`\`\`json
+          {
+            \"dependencies\": {
+              \"@coral-xyz/anchor\": \"https://github.com/coral-xyz/anchor/releases/download/nightly-${NIGHTLY_VERSION}/anchor-${NIGHTLY_VERSION}.tgz\"
+            }
+          }
+          \`\`\`" \
+            --prerelease \
+            ./anchor-cli-*.tgz \
+            ./anchor-*.tgz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Keep only the 7 most recent nightly releases
+      - name: Delete old nightly releases
+        run: |
+          gh release list --limit 50 | grep "nightly-" | tail -n +8 | while IFS=$'\t' read -r tag rest; do
+            echo "Deleting old nightly release: $tag"
+            gh release delete "$tag" --yes || echo "Failed to delete $tag"
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ To jump straight to examples, go [here](https://github.com/coral-xyz/anchor/tree
 | `@coral-xyz/anchor`     | TypeScript client for Anchor programs                    | [![npm](https://img.shields.io/npm/v/@coral-xyz/anchor.svg?color=blue)](https://www.npmjs.com/package/@coral-xyz/anchor)         | [![Docs](https://img.shields.io/badge/docs-typedoc-blue)](https://coral-xyz.github.io/anchor/ts/index.html)     |
 | `@coral-xyz/anchor-cli` | CLI to support building and managing an Anchor workspace | [![npm](https://img.shields.io/npm/v/@coral-xyz/anchor-cli.svg?color=blue)](https://www.npmjs.com/package/@coral-xyz/anchor-cli) | [![Docs](https://img.shields.io/badge/docs-typedoc-blue)](https://coral-xyz.github.io/anchor/cli/commands.html) |
 
+## Nightly Builds
+
+For testing unreleased features, nightly builds are available:
+
+- **CLI**: Download from [GitHub Releases](https://github.com/coral-xyz/anchor/releases) (look for `nightly-*` tags)
+- **TypeScript**: Download from [GitHub Releases](https://github.com/coral-xyz/anchor/releases) or reference directly in package.json
+
+⚠️ **Warning**: Nightly builds are unstable and may contain breaking changes.
+
 ## Note
 
 - **Anchor is in active development, so all APIs are subject to change.**


### PR DESCRIPTION
### Summary

This PR adds a nightly build workflow for the anchor CLI and anchor ts client package. Nightly builds are published to GitHub Releases with `nightly-*` tags, allowing users to test unreleased features and changes.

### Details

- Adds a GitHub Actions workflow to build and package the CLI and TypeScript client nightly.
- Nightly tarballs are uploaded to GitHub Releases (see `nightly-*` tags).
- Updates the README with instructions for downloading nightly builds and a warning about instability.

fixes #1911 