### PR TITLE
fixed the safety-checks link issue, updated to account-validation

### DIFF
--- a/lang/syn/src/parser/context.rs
+++ b/lang/syn/src/parser/context.rs
@@ -72,7 +72,7 @@ impl CrateContext {
         Please add a `/// CHECK:` doc comment explaining why no checks through types are necessary.
         Alternatively, for reasons like quick prototyping, you may disable the safety checks
         by using the `skip-lint` option.
-        See https://www.anchor-lang.com/docs/the-accounts-struct#safety-checks for more information.
+        See https://www.anchor-lang.com/docs/basics/program-structure#account-validation for more information.
                     "#,
                         ctx.file.canonicalize().unwrap().display(),
                         span.start().line,


### PR DESCRIPTION
this solves issue #3786 
Replaces outdated safety checks documentation link in error messages with the correct section:
basics/program-structure#account-validation