### PR TITLE
fixed-recentblockhash-overwritten

### DIFF
--- a/ts/packages/anchor/src/provider.ts
+++ b/ts/packages/anchor/src/provider.ts
@@ -150,10 +150,11 @@ export class AnchorProvider implements Provider {
       }
     } else {
       tx.feePayer = tx.feePayer ?? this.wallet.publicKey;
-      tx.recentBlockhash = (
-        await this.connection.getLatestBlockhash(opts.preflightCommitment)
-      ).blockhash;
-
+      if(!tx.recentBlockhash){
+        tx.recentBlockhash = (
+          await this.connection.getLatestBlockhash(opts.preflightCommitment)
+        ).blockhash;
+      }
       if (signers) {
         for (const signer of signers) {
           tx.partialSign(signer);
@@ -228,8 +229,9 @@ export class AnchorProvider implements Provider {
         let signers = r.signers ?? [];
 
         tx.feePayer = tx.feePayer ?? this.wallet.publicKey;
-        tx.recentBlockhash = recentBlockhash;
-
+        if(!tx.recentBlockhash){
+          tx.recentBlockhash = recentBlockhash;
+        }
         signers.forEach((kp) => {
           tx.partialSign(kp);
         });


### PR DESCRIPTION
Fixed the Issue  #3375 

issue description :

Currently, the AnchorProvider offers the following methods for sending transactions:

 1. `sendAndConfirm`
 2. `sendAll`
However, issues arise when using durable nonces because the recentBlockhash field gets overwritten. It would be beneficial to add a check to determine if the field is already set or to make the sendAndConfirmRawTransaction method public to provide more flexibility.

Fixed By adding If statement check!

