### PR TITLE
docs: fix typo

### DIFF
--- a/tests/zero-copy/programs/zero-copy/src/lib.rs
+++ b/tests/zero-copy/programs/zero-copy/src/lib.rs
@@ -170,7 +170,7 @@ pub struct Event {
 //    traits, so any types in method signatures must as well.
 // 2. All types for zero copy deserialization are `#[repr(packed)]`. However,
 //    the implementation of AnchorSerialize (i.e. borsh), uses references
-//    to the fields it serializes. So if we were to just throw tehse derives
+//    to the fields it serializes. So if we were to just throw these derives
 //    onto the other `Event` struct, we would have references to
 //    `#[repr(packed)]` fields, which is unsafe. To avoid the unsafeness, we
 //    just use a separate type.

--- a/ts/packages/spl-token/program/lib.rs
+++ b/ts/packages/spl-token/program/lib.rs
@@ -438,7 +438,7 @@ pub enum TokenError {
     #[msg("Invalid number of required signers")]
     InvalidNumberOfRequiredSigners,
     /// State is uninitialized.
-    #[msg("State is unititialized")]
+    #[msg("State is uninitialized")]
     UninitializedState,
 
     // 10


### PR DESCRIPTION
`tehse` to `these`
`unititialized` to `uninitialized`