### PR TITLE
refactor: use `BTreeMap`s and `BTreeSet`s instead of hashmaps and hashsets

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -13,7 +13,7 @@ use solana_cli_config::{Config as SolanaConfig, CONFIG_FILE};
 use solana_sdk::clock::Slot;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::fs::{self, File};
 use std::io::prelude::*;
@@ -766,11 +766,11 @@ impl From<TestValidator> for _TestValidator {
 
 #[derive(Debug, Clone)]
 pub struct TestConfig {
-    pub test_suite_configs: HashMap<PathBuf, TestToml>,
+    pub test_suite_configs: BTreeMap<PathBuf, TestToml>,
 }
 
 impl Deref for TestConfig {
-    type Target = HashMap<PathBuf, TestToml>;
+    type Target = BTreeMap<PathBuf, TestToml>;
 
     fn deref(&self) -> &Self::Target {
         &self.test_suite_configs
@@ -780,7 +780,7 @@ impl Deref for TestConfig {
 impl TestConfig {
     pub fn discover(root: impl AsRef<Path>, test_paths: Vec<PathBuf>) -> Result<Option<Self>> {
         let walker = WalkDir::new(root).into_iter();
-        let mut test_suite_configs = HashMap::new();
+        let mut test_suite_configs = BTreeMap::new();
         for entry in walker.filter_entry(|e| !is_hidden(e)) {
             let entry = entry?;
             if entry.file_name() == "Test.toml" {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -31,9 +31,7 @@ use solana_sdk::signature::Keypair;
 use solana_sdk::signature::Signer;
 use solana_sdk::signer::EncodableKey;
 use solana_sdk::transaction::Transaction;
-use std::collections::BTreeMap;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::fs::{self, File};
 use std::io::prelude::*;
@@ -3267,7 +3265,7 @@ fn validator_flags(
                             Pubkey::from_str(address)
                                 .map_err(|_| anyhow!("Invalid pubkey {}", address))
                         })
-                        .collect::<Result<HashSet<Pubkey>>>()?
+                        .collect::<Result<BTreeSet<Pubkey>>>()?
                         .into_iter()
                         .collect::<Vec<_>>();
                     let accounts = client.get_multiple_accounts(&pubkeys)?;
@@ -3998,7 +3996,7 @@ fn shell(cfg_override: &ConfigOverride) -> Result<()> {
     with_workspace(cfg_override, |cfg| {
         let programs = {
             // Create idl map from all workspace programs.
-            let mut idls: HashMap<String, Idl> = cfg
+            let mut idls: BTreeMap<String, Idl> = cfg
                 .read_all_programs()?
                 .iter()
                 .filter(|program| program.idl.is_some())

--- a/lang/syn/src/codegen/accounts/__client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__client_accounts.rs
@@ -124,7 +124,7 @@ pub fn generate(
     // accounts used for structs.
     let re_exports: Vec<proc_macro2::TokenStream> = {
         // First, dedup the exports.
-        let mut re_exports = std::collections::HashSet::new();
+        let mut re_exports = std::collections::BTreeSet::new();
         for f in accs.fields.iter().filter_map(|f: &AccountField| match f {
             AccountField::CompositeField(s) => Some(s),
             AccountField::Field(_) => None,

--- a/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
@@ -137,7 +137,7 @@ pub fn generate(
     // accounts used for structs.
     let re_exports: Vec<proc_macro2::TokenStream> = {
         // First, dedup the exports.
-        let mut re_exports = std::collections::HashSet::new();
+        let mut re_exports = std::collections::BTreeSet::new();
         for f in accs.fields.iter().filter_map(|f: &AccountField| match f {
             AccountField::CompositeField(s) => Some(s),
             AccountField::Field(_) => None,

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -1,5 +1,5 @@
 use quote::{format_ident, quote};
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use crate::*;
 
@@ -1560,14 +1560,14 @@ fn generate_constraint_mint(
 
 #[derive(Clone, Debug)]
 pub struct OptionalCheckScope<'a> {
-    seen: HashSet<String>,
+    seen: BTreeSet<String>,
     accounts: &'a AccountsStruct,
 }
 
 impl<'a> OptionalCheckScope<'a> {
     pub fn new(accounts: &'a AccountsStruct) -> Self {
         Self {
-            seen: HashSet::new(),
+            seen: BTreeSet::new(),
             accounts,
         }
     }

--- a/lang/syn/src/codegen/program/accounts.rs
+++ b/lang/syn/src/codegen/program/accounts.rs
@@ -3,7 +3,7 @@ use heck::SnakeCase;
 use quote::quote;
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
-    let mut accounts = std::collections::HashMap::new();
+    let mut accounts = std::collections::BTreeMap::new();
 
     // Go through instruction accounts.
     for ix in &program.ixs {

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -95,7 +95,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
 }
 
 pub fn generate_accounts(program: &Program) -> proc_macro2::TokenStream {
-    let mut accounts = std::collections::HashMap::new();
+    let mut accounts = std::collections::BTreeMap::new();
 
     // Go through instruction accounts.
     for ix in &program.ixs {

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -18,7 +18,7 @@ use parser::program as program_parser;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use quote::ToTokens;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::ops::Deref;
 use syn::ext::IdentExt;
 use syn::parse::{Error as ParseError, Parse, ParseStream, Result as ParseResult};
@@ -192,7 +192,7 @@ impl AccountsStruct {
     // Return value maps instruction name to type.
     // E.g. if we have `#[instruction(data: u64)]` then returns
     // { "data": "u64"}.
-    pub fn instruction_args(&self) -> Option<HashMap<String, String>> {
+    pub fn instruction_args(&self) -> Option<BTreeMap<String, String>> {
         self.instruction_api.as_ref().map(|instruction_api| {
             instruction_api
                 .iter()


### PR DESCRIPTION
### Motivation

using more  lightweight structs to improve performance and further compatibility with `no_std`