### PR TITLE
refactor: use workspace deps in AVM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,23 @@ members = [
 ]
 exclude = ["tests/cfo/deps/openbook-dex", "tests/swap/deps/openbook-dex"]
 resolver = "2"
+
+[workspace.package]
+edition = "2021"
+
+[workspace.dependencies]
+anyhow = "1.0.32"
+cargo_toml = "0.19.2"
+cfg-if = "1.0.0"
+chrono = "0.4"
+clap = { version = "4.5.17", default-features = false }
+clap_complete = "4.5.26"
+dirs = "4.0.0"
+reqwest = { version = "0.11.9", default-features = false }
+semver = "1.0.4"
+serde = { version = "1.0.136", default-features = false }
+tempfile = "3.3.0"
+
 [profile.release]
 lto = true
 

--- a/avm/Cargo.toml
+++ b/avm/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "avm"
 version = "0.31.1"
-edition = "2021"
+edition.workspace = true
 
 [[bin]]
 name = "avm"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1.0.32"
-cargo_toml = "0.19.2"
-cfg-if = "1.0.0"
-chrono = "0.4"
-clap = { version = "4.5.17", features = ["derive"] }
-clap_complete = "4.5.26"
-dirs = "4.0.0"
-reqwest = { version = "0.11.9", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-semver = "1.0.4"
-serde = { version = "1.0.136", features = ["derive"] }
+anyhow.workspace = true
+cargo_toml.workspace = true
+cfg-if.workspace = true
+chrono.workspace = true
+clap = { workspace = true, features = ["derive"] }
+clap_complete.workspace = true
+dirs.workspace = true
+reqwest = { workspace = true, features = ["blocking", "json", "rustls-tls"] }
+semver.workspace = true
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-tempfile = "3.3.0"
+tempfile.workspace = true


### PR DESCRIPTION
### Problem

this is tedious to manage dependency version because you have to run through all the codebase and figure out where it used

### Solution

as a proof of concept - the first migrated member `avm`

related to #3892 