### PR TITLE
fix: correct line number reporting for missing CHECK errors on duplic…

### DIFF
--- a/tests/safety-checks/test.sh
+++ b/tests/safety-checks/test.sh
@@ -7,7 +7,7 @@ echo "Building programs"
 #
 pushd programs/unchecked-account/
 output=$(anchor build 2>&1 > /dev/null)
-if ! [[ $output =~ "Struct field \"unchecked\" is unsafe" ]]; then
+if ! [[ $output =~ "Struct field \"unchecked\" in struct \"Initialize\" is unsafe" ]]; then
    echo "Error: expected /// CHECK error"
    exit 1
 fi
@@ -18,7 +18,7 @@ popd
 #
 pushd programs/account-info/
 output=$(anchor build 2>&1 > /dev/null)
-if ! [[ $output =~ "Struct field \"unchecked\" is unsafe" ]]; then
+if ! [[ $output =~ "Struct field \"unchecked\" in struct \"Initialize\" is unsafe" ]]; then
    echo "Error: expected /// CHECK error"
    exit 1
 fi


### PR DESCRIPTION


- Fix safety_checks() method to iterate through structs explicitly instead of using generic unsafe_struct_fields()
- Add struct name to error messages for better context when duplicate field names exist
- Remove unused unsafe_struct_fields() method
- Update test expectations to match new error message format

Fixes #3915