### PR TITLE
docs(README.md): add contributing badge to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     <a href="https://anchor-lang.com"><img alt="Tutorials" src="https://img.shields.io/badge/docs-tutorials-blueviolet" /></a>
     <a href="https://discord.gg/NHHGSXAnXk"><img alt="Discord Chat" src="https://img.shields.io/discord/889577356681945098?color=blueviolet" /></a>
     <a href="https://opensource.org/licenses/Apache-2.0"><img alt="License" src="https://img.shields.io/github/license/coral-xyz/anchor?color=blueviolet" /></a>
+    <a href="https://github.com/solana-foundation/anchor/blob/master/CONTRIBUTING.md"><img alt="Contributing" src="https://img.shields.io/badge/Contributing-welcome-brightgreen.svg?color=blueviolet" /></a>
   </p>
 </div>
 


### PR DESCRIPTION
Added informative Contributing badge to the top of the README to improve repository visibility and encourage community contributions.

- [Contributing] badge links to the Contributing section within README

Brief comments on the purpose of your changes:

This change improves the first impression of the repository by adding two badges that clearly communicate the license type and encourage contributions. It follows common open-source standards and enhances the project’s visual appeal and contributor friendliness.

No functional or code changes.
